### PR TITLE
Added Bluesky link to footer

### DIFF
--- a/src/components/custom-link.tsx
+++ b/src/components/custom-link.tsx
@@ -5,12 +5,23 @@ export default function CustomLink({
   children,
   href,
   underline = false,
+  newTab = false, 
 }: Readonly<{
   children: React.ReactNode;
   href: string;
   underline?: boolean;
+  newTab?: boolean;
 }>) {
-  return (
+  return newTab ? (
+    <a
+      href={href}
+      className={cn(underline ? "underline" : "")}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  ) : (
     <Link href={href} className={cn(underline ? "underline" : "")}>
       {children}
     </Link>

--- a/src/components/custom-link.tsx
+++ b/src/components/custom-link.tsx
@@ -5,24 +5,20 @@ export default function CustomLink({
   children,
   href,
   underline = false,
-  newTab = false, 
+  newTab = false,
 }: Readonly<{
   children: React.ReactNode;
   href: string;
   underline?: boolean;
   newTab?: boolean;
 }>) {
-  return newTab ? (
-    <a
+  return (
+    <Link
       href={href}
       className={cn(underline ? "underline" : "")}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={newTab ? "_blank" : undefined}
+      rel={newTab ? "noopener noreferrer" : undefined}
     >
-      {children}
-    </a>
-  ) : (
-    <Link href={href} className={cn(underline ? "underline" : "")}>
       {children}
     </Link>
   );

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -46,8 +46,8 @@ export default function Footer() {
             </CustomLink>
             <br />
 
-            <CustomLink href="https://github.com/accuguide" newTab>
-              Accuguide
+            <CustomLink href="https://bsky.app/profile/accuguide.org" newTab>
+              Bluesky
             </CustomLink>
           </div>
           <div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -44,6 +44,11 @@ export default function Footer() {
             <CustomLink href="https://github.com/accuguide/accuguide">
               Github
             </CustomLink>
+            <br />
+
+            <CustomLink href="https://github.com/accuguide" newTab>
+              Accuguide
+            </CustomLink>
           </div>
           <div>
             <h3 className="mb-1">Legal</h3>


### PR DESCRIPTION
1. I’ve added https://github.com/accuguide as the 3rd contact link.

2. Committed changes in two files — one of them is the custom link component, which now supports a newTab prop so you can open any link in a new tab just by adding that prop.

3. Used the same spacing and UI elements as the rest for a seamless integration.