### PR TITLE
Use location access for relevant search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "drizzle-orm": "^0.44.1",
         "geist": "^1.4.2",
         "groq-sdk": "^0.23.0",
+        "js-cookie": "^3.0.5",
         "lucide-react": "^0.525.0",
         "next": "15.3.3",
         "next-themes": "^0.4.6",
@@ -42,6 +43,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^24",
         "@types/pg": "^8.15.2",
         "@types/react": "^19",
@@ -4816,6 +4818,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -9462,6 +9471,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "drizzle-orm": "^0.44.1",
     "geist": "^1.4.2",
     "groq-sdk": "^0.23.0",
+    "js-cookie": "^3.0.5",
     "lucide-react": "^0.525.0",
     "next": "15.3.3",
     "next-themes": "^0.4.6",
@@ -61,6 +62,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^24",
     "@types/pg": "^8.15.2",
     "@types/react": "^19",

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,12 +7,20 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const query = searchParams.get("query") || "";
+  const latitude = searchParams.get("latitude");
+  const longitude = searchParams.get("longitude");
   const apiKey = process.env.GOOGLE_MAPS_API_KEY;
   if (!apiKey) {
     return NextResponse.json({ error: "API key not found" }, { status: 500 });
   }
 
-  const url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${query}&key=${apiKey}`;
+  // Build URL with optional location parameters
+  let url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(query)}&key=${apiKey}`;
+
+  // Only add location and radius if both latitude and longitude are provided
+  if (latitude && longitude) {
+    url += `&location=${latitude},${longitude}&radius=5000`;
+  }
 
   try {
     const response = await fetch(url);
@@ -39,8 +47,11 @@ export async function GET(request: NextRequest) {
       const searchDbQuery = sql`(
         setweight(to_tsvector('english', ${entityTable.name}), 'A') ||
         setweight(to_tsvector('english', ${entityTable.city}), 'A') ||
+        setweight(to_tsvector('english', ${entityTable.state || ""}), 'A') ||
         setweight(to_tsvector('english', ${entityTable.displayType}), 'A') ||
-        setweight(to_tsvector('english', ${entityTable.description}), 'B')
+        setweight(to_tsvector('english', ${entityTable.type}), 'B') ||
+        setweight(to_tsvector('english', ${entityTable.description || ""}), 'B')
+
         @@ to_tsquery('english', ${formattedQuery})
       )`;
       const dbResponse = await db

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
 
   // Only add location and radius if both latitude and longitude are provided
   if (latitude && longitude) {
-    url += `&location=${latitude},${longitude}&radius=5000`;
+    url += `&location=${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}&radius=5000`;
   }
 
   try {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Hero from "@/components/hero";
+import Location from "@/components/location";
 import Search from "@/components/search";
 import Title from "@/components/title";
 
@@ -8,6 +9,7 @@ export default async function Page() {
       <Title>Welcome to Accuguide</Title>
       <Search size="full" />
       <Hero />
+      <Location />
     </div>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import Cookies from "js-cookie";
 import { SearchDisplayProps } from "@/types";
 import SearchDisplay from "@/components/search-display";
 
@@ -15,7 +16,16 @@ function SearchResults() {
 
   useEffect(() => {
     if (query) {
-      fetch(`/api/search/?query=${query}`)
+      // Get latitude and longitude from cookies
+      const latitude = Cookies.get("latitude");
+      const longitude = Cookies.get("longitude");
+
+      // Build query parameters
+      const params = new URLSearchParams({ query });
+      if (latitude) params.append("latitude", latitude);
+      if (longitude) params.append("longitude", longitude);
+
+      fetch(`/api/search/?${params.toString()}`)
         .then((response) => {
           return response.json();
         })

--- a/src/components/location.tsx
+++ b/src/components/location.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Location() {
+  function setCookie(name: string, value: string, days: number = 30) {
+    const date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    const expires = "expires=" + date.toUTCString();
+    document.cookie = name + "=" + value + ";" + expires + ";path=/";
+  }
+
+  function getLocation() {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const latitude = position.coords.latitude;
+          const longitude = position.coords.longitude;
+
+          console.log("Latitude: " + latitude);
+          console.log("Longitude: " + longitude);
+
+          // Set cookies for latitude and longitude
+          setCookie("latitude", latitude.toString());
+          setCookie("longitude", longitude.toString());
+        },
+        (error) => {
+          console.error("Error getting location: ", error);
+        },
+      );
+    }
+  }
+  useEffect(() => {
+    getLocation();
+  }, []);
+
+  return <div></div>;
+}

--- a/src/components/location.tsx
+++ b/src/components/location.tsx
@@ -1,15 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
+import Cookies from "js-cookie";
 
 export default function Location() {
-  function setCookie(name: string, value: string, days: number = 30) {
-    const date = new Date();
-    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
-    const expires = "expires=" + date.toUTCString();
-    document.cookie = name + "=" + value + ";" + expires + ";path=/";
-  }
-
   function getLocation() {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
@@ -17,12 +11,8 @@ export default function Location() {
           const latitude = position.coords.latitude;
           const longitude = position.coords.longitude;
 
-          console.log("Latitude: " + latitude);
-          console.log("Longitude: " + longitude);
-
-          // Set cookies for latitude and longitude
-          setCookie("latitude", latitude.toString());
-          setCookie("longitude", longitude.toString());
+          Cookies.set("latitude", latitude.toString(), { expires: 30 });
+          Cookies.set("longitude", longitude.toString(), { expires: 30 });
         },
         (error) => {
           console.error("Error getting location: ", error);

--- a/src/components/location.tsx
+++ b/src/components/location.tsx
@@ -11,8 +11,14 @@ export default function Location() {
           const latitude = position.coords.latitude;
           const longitude = position.coords.longitude;
 
-          Cookies.set("latitude", latitude.toString(), { expires: 30 });
-          Cookies.set("longitude", longitude.toString(), { expires: 30 });
+          Cookies.set("latitude", latitude.toString(), {
+            expires: 30,
+            secure: true,
+          });
+          Cookies.set("longitude", longitude.toString(), {
+            expires: 30,
+            secure: true,
+          });
         },
         (error) => {
           console.error("Error getting location: ", error);


### PR DESCRIPTION
Closes Issue #53 
If user permits usage of location, they get relevant entities, otherwise, entities will not be specific to their location.