### PR TITLE
feat(entity): add Get Directions button to entity page

### DIFF
--- a/src/components/entity-display.tsx
+++ b/src/components/entity-display.tsx
@@ -71,6 +71,16 @@ export default async function EntityDisplay({
         <br />
         {data?.country}
       </p>
+      {data?.address1 && data?.city && data?.country && (
+        <a
+          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${data.address1}${data.address2 ? ' ' + data.address2 : ''}, ${data.city}, ${data.state ? data.state + ' ' : ''}${data.zip ? data.zip + ' ' : ''}${data.country}`)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+        >
+          Get Directions
+        </a>
+      )}
       <h2>Website</h2>
       <CustomLink href={data?.url || " "} underline>
         {data?.url}


### PR DESCRIPTION
## Summary

This PR adds a "Get Directions" button below the address section on the entity page. The button allows users to quickly open the entity's address in Google Maps for easy navigation.

## Details

- The button appears only if the entity has address, city, and country information.
- Clicking the button opens Google Maps in a new tab with the destination pre-filled.
- Improves accessibility and user experience by providing direct access to directions.

closes #50 