### PR TITLE
fix(UX): Adding error toast message on failed singin (fixes: #86)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.57.0",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.0",
         "uuid": "^11.1.0",
         "zod": "^3.25.51"
@@ -12636,6 +12637,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.57.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.0",
     "uuid": "^11.1.0",
     "zod": "^3.25.51"

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,5 +1,11 @@
 import SigninForm from "@/components/forms/signin-form";
+import { Toaster } from "@/components/ui/sonner"
 
 export default function Page() {
-  return <SigninForm />;
+  return (
+    <>
+      <Toaster position="top-center" richColors/>
+      <SigninForm />
+    </>
+  );
 }

--- a/src/components/forms/signin-form.tsx
+++ b/src/components/forms/signin-form.tsx
@@ -18,9 +18,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import FormContainer from "./form-container";
 import LegalAgreement from "@/components/forms/legal-agreement";
 import Link from "next/link";
+import { toast } from "sonner"
 
 const formSchema = z.object({
-  email: z.string(),
+  email: z.string().email("Please enter a valid email"),
   password: z.string(),
 });
 
@@ -33,8 +34,14 @@ export default function SigninForm() {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    signInWithEmail(values.email, values.password);
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+      const { error } = await signInWithEmail(values.email, values.password);
+      
+      if (error != null) {
+      toast.error("There was an error logging you in", {
+          description: `${error.message}`,
+        })
+      }
   }
 
   return (

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
This PR adds the shadcn toast ui component to the sigin-in page as requrested in #86
Here is a screenshot of the UI now when we enter invalid credentials
<img width="1919" height="964" alt="result" src="https://github.com/user-attachments/assets/60969c96-c77a-4032-a4b9-b56a04145086" />

- Added shadcn toast as dependency
- Integrated the component in sing-in/page.tsx