### PR TITLE
fix: location request occurs only on search page

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -19,15 +19,15 @@ function SearchResults() {
     latitude,
     longitude,
     isLocationChecked,
-    status,                // ← Added this
-    requestLocation        // ← Added this
-  } = useLocation()        // ← Updated destructuring to include status & requestLocation
+    status, // ← Added this
+    requestLocation, // ← Added this
+  } = useLocation() // ← Updated destructuring to include status & requestLocation
 
   const [locations, setLocations] = useState<PointOfInterest[]>([])
 
   // NEW: Trigger location request ONLY here, after search query exists
   useEffect(() => {
-    if (!query?.trim()) return;  // No query → skip (not a real search)
+    if (!query?.trim()) return // No query → skip (not a real search)
 
     // Only request if:
     // - Location not yet checked/granted
@@ -37,11 +37,11 @@ function SearchResults() {
       isLocationChecked &&
       status !== 'granted' &&
       status !== 'requesting' &&
-      status !== 'denied'   // ← Optional: remove if you want to re-prompt on every search
+      status !== 'denied' // ← Optional: remove if you want to re-prompt on every search
     ) {
-      requestLocation();
+      requestLocation()
     }
-  }, [query, isLocationChecked, status, requestLocation]);
+  }, [query, isLocationChecked, status, requestLocation])
 
   useEffect(() => {
     if (!query || !isLocationChecked) {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -15,8 +15,33 @@ function SearchResults() {
   const [isLoading, setIsLoading] = useState(false)
   const searchParams = useSearchParams()
   const query = searchParams.get('query')
-  const { latitude, longitude, isLocationChecked } = useLocation()
+  const {
+    latitude,
+    longitude,
+    isLocationChecked,
+    status,                // ← Added this
+    requestLocation        // ← Added this
+  } = useLocation()        // ← Updated destructuring to include status & requestLocation
+
   const [locations, setLocations] = useState<PointOfInterest[]>([])
+
+  // NEW: Trigger location request ONLY here, after search query exists
+  useEffect(() => {
+    if (!query?.trim()) return;  // No query → skip (not a real search)
+
+    // Only request if:
+    // - Location not yet checked/granted
+    // - Not already requesting
+    // - Not permanently denied (optional: you can prompt again if wanted)
+    if (
+      isLocationChecked &&
+      status !== 'granted' &&
+      status !== 'requesting' &&
+      status !== 'denied'   // ← Optional: remove if you want to re-prompt on every search
+    ) {
+      requestLocation();
+    }
+  }, [query, isLocationChecked, status, requestLocation]);
 
   useEffect(() => {
     if (!query || !isLocationChecked) {

--- a/src/contexts/location-context.tsx
+++ b/src/contexts/location-context.tsx
@@ -39,7 +39,7 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
   const [isLocationChecked, setIsLocationChecked] = useState(false)
 
   const requestLocation = useCallback(() => {
-    if (status === 'requesting' || status === 'granted') return;
+    if (status === 'requesting' || status === 'granted') return
 
     if (!navigator.geolocation) {
       setStatus('unavailable')

--- a/src/contexts/location-context.tsx
+++ b/src/contexts/location-context.tsx
@@ -39,7 +39,7 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
   const [isLocationChecked, setIsLocationChecked] = useState(false)
 
   const requestLocation = useCallback(() => {
-    if (status === 'requesting') return
+    if (status === 'requesting' || status === 'granted') return;
 
     if (!navigator.geolocation) {
       setStatus('unavailable')
@@ -123,11 +123,12 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  useEffect(() => {
-    if (isLocationChecked && status === 'idle') {
-      requestLocation()
-    }
-  }, [isLocationChecked, status, requestLocation])
+  //code causing the auto request issue
+  // useEffect(() => {
+  //   if (isLocationChecked && status === 'idle') {
+  //     requestLocation()
+  //   }
+  // }, [isLocationChecked, status, requestLocation])
 
   const value: LocationContextValue = {
     latitude,


### PR DESCRIPTION
Closes #218

## Problem
The location permission request was being triggered automatically on every page load via a `useEffect` in `LocationProvider` that called `requestLocation()` whenever `status === 'idle'`. This meant users were prompted for location access even when they hadn't performed a search yet, which felt intrusive and unnecessary.

## Changes

### `app/contexts/location-context.tsx`
- Removed the `useEffect` that automatically triggered `requestLocation()` on mount/idle status — this was the root cause of the issue
- Added a `status === 'granted'` guard inside `requestLocation()` to prevent duplicate requests if location is already known

### `app/search/page.tsx`
- Added a new `useEffect` that calls `requestLocation()` only when a search query exists
- Destructured `status` and `requestLocation` from `useLocation()` to support the new logic
- Location is only requested once per session — skips if already `granted`, `requesting`, or `denied`

## Result
Users are no longer prompted for location on pages where it isn't needed. The permission request now fires contextually — only after the user has initiated a search — which is a more respectful and intentional UX pattern.