### PR TITLE
Add server-side pagination for search results (closes #244)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -10,40 +10,86 @@ export async function GET(request: NextRequest) {
     const query = searchParams.get('query') || ''
     const latitude = searchParams.get('latitude')
     const longitude = searchParams.get('longitude')
+    // "page" tells us which chunk of results to send back.
+    // If the frontend doesn't send one (e.g. first load), we default to page 1.
+    const page = Number(searchParams.get('page')) || 1
+    const PAGE_SIZE = 12 // how many DB results per page — pick any number that looks good in the grid
+    // How many rows to skip before we start collecting results.
+    // e.g. page 1 → skip 0, page 2 → skip 12, page 3 → skip 24 (with PAGE_SIZE = 12)
+    const offset = (page - 1) * PAGE_SIZE
+    let totalMatches = 0 // default: assume no matches, until we actually check
     const apiKey = process.env.BACKEND_GOOGLE_MAPS_API_KEY
+    // If the frontend already clicked "Next" once, it will send back the token
+    // Google gave us last time. If this is missing, it means "give me page 1."
+    const googlePageToken = searchParams.get('googlePageToken')
+
+    // If the frontend is only paging the DB list (via Previous/Next),
+    // it sets dbOnly=true — meaning "don't bother calling Google at all this time."
+    const dbOnly = searchParams.get('dbOnly') === 'true'
+
     if (!apiKey) {
       return NextResponse.json({ error: 'API key not found' }, { status: 500 })
     }
 
-    // Build URL with optional location parameters
-    let url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(query)}&key=${apiKey}`
+    // IMPORTANT beginner concept: when you have a page token, Google wants
+    // ONLY the token + key — no query text, no location. Google already
+    // remembers what you searched for and where, tied to that token.
+    // Sending query/location again alongside a token actually confuses the request.
+    let formattedGoogleResponse: SearchDisplayType[] = []
+    let googleResponse: {
+      status?: string
+      results?: GoogleSearchResponse[]
+      next_page_token?: string
+    } = {}
 
-    // Only add location and radius if both latitude and longitude are provided
-    if (latitude && longitude) {
-      url += `&location=${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}&radius=5000`
-    }
+    if (!dbOnly) {
+      let url: string
+      if (googlePageToken) {
+        url = `https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=${encodeURIComponent(googlePageToken)}&key=${apiKey}`
+      } else {
+        url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(query)}&key=${apiKey}`
+        if (latitude && longitude) {
+          url += `&location=${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}&radius=5000`
+        }
+      }
 
-    const response = await fetch(url)
-    if (!response.ok) {
-      return NextResponse.json(
-        {
-          error:
-            '[api/search GET] error: Failed to fetch data from Google Places API',
-        },
-        { status: response.status },
+      async function fetchGooglePlaces(requestUrl: string) {
+        const res = await fetch(requestUrl)
+        const json = await res.json()
+        return { res, json }
+      }
+
+      let { res: response, json: json1 } = await fetchGooglePlaces(url)
+      googleResponse = json1
+
+      if (googlePageToken && googleResponse.status === 'INVALID_REQUEST') {
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+        const retry = await fetchGooglePlaces(url)
+        response = retry.res
+        googleResponse = retry.json
+      }
+
+      if (!response.ok) {
+        return NextResponse.json(
+          {
+            error:
+              '[api/search GET] error: Failed to fetch data from Google Places API',
+          },
+          { status: response.status },
+        )
+      }
+
+      formattedGoogleResponse = (googleResponse.results ?? []).map(
+        (place: GoogleSearchResponse) => ({
+          googleId: place.place_id,
+          name: place.name,
+          address: place.formatted_address,
+          type: place.types[0],
+          lat: place.geometry.location.lat,
+          lng: place.geometry.location.lng,
+        }),
       )
     }
-
-    const googleResponse = await response.json()
-    const formattedGoogleResponse: SearchDisplayType[] =
-      googleResponse.results.map((place: GoogleSearchResponse) => ({
-        googleId: place.place_id,
-        name: place.name,
-        address: place.formatted_address,
-        type: place.types[0],
-        lat: place.geometry.location.lat,
-        lng: place.geometry.location.lng,
-      }))
 
     const formattedQuery = query.replace(/\s+/g, ' & ') + ':*'
     let formattedDbResponse: SearchDisplayType[] = []
@@ -59,10 +105,22 @@ export async function GET(request: NextRequest) {
 
         @@ to_tsquery('english', ${formattedQuery})
       )`
+
       const dbResponse = await db
         .select()
         .from(entityTable)
         .where(searchDbQuery)
+        .limit(PAGE_SIZE) // <-- only grab this many rows
+        .offset(offset) // <-- ...after skipping this many
+
+      // We ALSO need to know the total number of matches (not just this page's worth),
+      // so the frontend can tell whether a "Next" page actually exists.
+      // Same filter (searchDbQuery), but counting rows instead of fetching them.
+      const [{ count: matchCount }] = await db
+        .select({ count: count() })
+        .from(entityTable)
+        .where(searchDbQuery)
+      totalMatches = matchCount // assign to the outer variable, don't redeclare it
 
       formattedDbResponse = dbResponse.map((place) => ({
         id: place.id,
@@ -84,10 +142,18 @@ export async function GET(request: NextRequest) {
       {
         loc: 'database',
         data: formattedDbResponse,
+        // true if there are still more matching rows after this page
+        hasMore: offset + formattedDbResponse.length < totalMatches,
+        // Exact number of DB result pages
+        totalPages: Math.ceil(totalMatches / PAGE_SIZE),
       },
       {
         loc: 'google',
         data: filteredGoogleResponse,
+        // If Google gave us a token for more results, pass it along.
+        // If there's nothing left, Google won't include this field, so we default to null —
+        // the frontend will use "is this null?" to decide whether to show a "Next" button.
+        nextPageToken: googleResponse.next_page_token || null,
       },
     ]
     return NextResponse.json(combinedResponse, { status: 200 })

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,17 @@ function SearchResults() {
   const [googleResponse, setGoogleResponse] = useState<SearchDisplayProps[]>([])
   const [dbResponse, setDbResponse] = useState<SearchDisplayProps[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  // Which DB page we're currently showing (starts at 1)
+  const [dbPage, setDbPage] = useState(1)
+  // Total DB pages returned by the API
+  const [dbTotalPages, setDbTotalPages] = useState(1)
+
+  // The token Google gave us to fetch its NEXT batch of results.
+  // null means "no more Google results" (or we haven't searched yet).
+  const [googleNextToken, setGoogleNextToken] = useState<string | null>(null)
+  // A separate loading flag just for the "Load More" button,
+  // so clicking it doesn't trigger the big full-page skeleton loader.
+  const [isLoadingMoreGoogle, setIsLoadingMoreGoogle] = useState(false)
   const searchParams = useSearchParams()
   const query = searchParams.get('query')
   const { latitude, longitude, isLocationChecked } = useLocation()
@@ -25,7 +36,7 @@ function SearchResults() {
 
     setIsLoading(true)
 
-    const params = new URLSearchParams({ query })
+    const params = new URLSearchParams({ query, page: '1' })
     if (latitude !== null && longitude !== null) {
       params.append('latitude', latitude.toString())
       params.append('longitude', longitude.toString())
@@ -41,6 +52,10 @@ function SearchResults() {
       .then((data) => {
         setGoogleResponse(data[1].data)
         setDbResponse(data[0].data)
+        // Fresh search — reset paging trackers for BOTH lists back to "page 1"
+        setDbPage(1)
+        setDbTotalPages(data[0].totalPages)
+        setGoogleNextToken(data[1].nextPageToken ?? null)
 
         const tempLocations: PointOfInterest[] = [
           ...data[0].data.map(
@@ -80,6 +95,61 @@ function SearchResults() {
       })
   }, [query, latitude, longitude, isLocationChecked])
 
+  function goToDbPage(newPage: number) {
+    if (!query) return
+
+    setDbPage(newPage)
+
+    const params = new URLSearchParams({
+      query,
+      page: newPage.toString(),
+      dbOnly: 'true',
+    })
+    if (latitude !== null && longitude !== null) {
+      params.append('latitude', latitude.toString())
+      params.append('longitude', longitude.toString())
+    }
+
+    fetch(`/api/search/?${params.toString()}`)
+      .then((response) => response.json())
+      .then((data) => {
+        // We ONLY touch the database part here.
+        // (This request also re-fetches Google's first page in the background,
+        // as a side effect of the two being one shared API route — we simply
+        // ignore that part so we don't disturb the Google list on screen.)
+        setDbResponse(data[0].data)
+        setDbTotalPages(data[0].totalPages)
+      })
+      .catch((error) =>
+        console.error(`[search] error changing DB page: ${error}`),
+      )
+  }
+
+  function loadMoreGoogleResults() {
+    if (!query || !googleNextToken) return
+
+    setIsLoadingMoreGoogle(true)
+
+    const params = new URLSearchParams({
+      query,
+      googlePageToken: googleNextToken,
+    })
+
+    fetch(`/api/search/?${params.toString()}`)
+      .then((response) => response.json())
+      .then((data) => {
+        // APPEND new results to the existing list, don't replace it —
+        // this is the natural pattern for token/cursor pagination:
+        // you're extending one continuous list, not jumping to a numbered page.
+        setGoogleResponse((prev) => [...prev, ...data[1].data])
+        setGoogleNextToken(data[1].nextPageToken ?? null)
+      })
+      .catch((error) =>
+        console.error(`[search] error loading more Google results: ${error}`),
+      )
+      .finally(() => setIsLoadingMoreGoogle(false))
+  }
+
   return (
     <div>
       <Location />
@@ -110,6 +180,55 @@ function SearchResults() {
                   />
                 ))}
               </div>
+
+              {/* Pagination controls */}
+              <div className="mt-6 flex items-center justify-center gap-2">
+                {/* Current page */}
+                <span className="mr-3 font-medium text-sm text-white">
+                  Page {dbPage} of {dbTotalPages}
+                </span>
+
+                {/* First page */}
+                <button
+                  onClick={() => goToDbPage(1)}
+                  disabled={dbPage === 1}
+                  aria-label="First page"
+                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/2 text-lg text-white transition-all duration-200 hover:cursor-pointer hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  «
+                </button>
+
+                {/* Previous page */}
+                <button
+                  onClick={() => goToDbPage(dbPage - 1)}
+                  disabled={dbPage === 1}
+                  aria-label="Previous page"
+                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/2 text-lg text-white transition-all duration-200 hover:cursor-pointer hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  ‹
+                </button>
+
+                {/* Next page */}
+                <button
+                  onClick={() => goToDbPage(dbPage + 1)}
+                  disabled={dbPage >= dbTotalPages}
+                  aria-label="Next page"
+                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/2 text-lg text-white transition-all duration-200 hover:cursor-pointer hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  ›
+                </button>
+
+                {/* Last page */}
+                <button
+                  onClick={() => goToDbPage(dbTotalPages)}
+                  disabled={dbPage >= dbTotalPages}
+                  aria-label="Last page"
+                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/2 text-lg text-white transition-all duration-200 hover:cursor-pointer hover:border-white/20 hover:bg-white/6 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  »
+                </button>
+              </div>
+
               <h2 className="mt-8 mb-4">All Results</h2>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {googleResponse.map((place) => (
@@ -124,6 +243,16 @@ function SearchResults() {
                   />
                 ))}
               </div>
+
+              {googleNextToken && (
+                <button
+                  onClick={loadMoreGoogleResults}
+                  disabled={isLoadingMoreGoogle}
+                  className="mt-4 rounded border px-3 py-1 disabled:opacity-40"
+                >
+                  {isLoadingMoreGoogle ? 'Loading…' : 'Load More'}
+                </button>
+              )}
             </div>
 
             {/* Sidebar map for large screens */}


### PR DESCRIPTION
Closes #244

## What this does
Adds backend-driven pagination to the search API and page, for both result sources:

- **Catalogued (DB) results** — offset/limit based pagination, with First/Previous/Next/Last controls and a page counter.
- **Google Places results** — token-based pagination (`next_page_token`), with a "Load More" button that appends results, matching how Google's API actually works (it doesn't support numbered pages).

Since the two sources paginate differently, they're handled independently rather than sharing one page number.

## Other changes
- Added a `dbOnly` query flag so that paging the DB results doesn't also trigger an unnecessary Google Places API call, since both sources previously ran on every request to this route.

## Testing
- Verified DB pagination manually (First/Previous/Next/Last, page counts, correct result sets per page) using seeded data.
- Verified the `dbOnly` flag prevents Google API calls in the logs when only paging DB results.
- Google-side pagination is implemented per their documented token flow, but I haven't been able to fully verify it end-to-end yet since billing isn't enabled on my test API key(which requires a prepayment of 1000 Rs). Happy to confirm this once that's sorted, or if a maintainer can test with a working key in the meantime.

## Notes
Open to feedback on the pagination page size (currently 12 for DB results) or the UI for the controls.